### PR TITLE
adding and embedding a privacy manifest

### DIFF
--- a/postbuild.sh
+++ b/postbuild.sh
@@ -4,8 +4,38 @@ if [ $# -lt 1 ]; then
   exit 2
 fi
 
+# Add in the privacy manifest that Apple's demanding for valid apps
+#
+THIS_SCRIPT_DIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+PRIVACY_FOLDER="${THIS_SCRIPT_DIR}/privacy"
+XCFRAMEWORK_FOLDER="${THIS_SCRIPT_DIR}/build_xcframework/OpenCV.xcframework"
+
+# macOS
+mkdir -p ${XCFRAMEWORK_FOLDER}/macos-arm64_x86_64/Versions/A/Resources
+cp ${PRIVACY_FOLDER}/PrivacyInfo.xcprivacy ${XCFRAMEWORK_FOLDER}/macos-arm64_x86_64/Versions/A/Resources
+
+# Mac Catalyst
+mkdir -p ${XCFRAMEWORK_FOLDER}/ios-arm64_x86_64-maccatalyst/Versions/A/Resources
+cp ${PRIVACY_FOLDER}/PrivacyInfo.xcprivacy ${XCFRAMEWORK_FOLDER}/ios-arm64_x86_64-maccatalyst/Versions/A/Resources
+
+# iOS
+cp ${PRIVACY_FOLDER}/PrivacyInfo.xcprivacy ${XCFRAMEWORK_FOLDER}/ios-arm64/
+
+# iOS simulator
+cp ${PRIVACY_FOLDER}/PrivacyInfo.xcprivacy ${XCFRAMEWORK_FOLDER}/ios-arm64_x86_64-simulator/
+
+# you might need to sign here at some point...
+# If you do codesign, do that BEFORE you zip it up
+#
+# codesign --timestamp -v --sign "Apple Development: ...your_id_here ..." OpenCV.xcframework
+
 cd build_xcframework
-zip -r OpenCV.xcframework.zip OpenCV.xcframework
+
+# zip works, but ditto is just a bit more robust for including contents that
+# Apple's fraameworks get all bent out of shape about. This setup doesn't
+# look like it stricly needs it - but if you ever include another framework
+# in here, it inflates incorrectly with zip.
+ditto -c -k --sequesterRsrc --keepParent OpenCV.xcframework OpenCV.xcframework.zip
 export vers=$1
 sed -I '' 's/\(download\/\).*\(\/\)/\1'$vers'\2/' ../Package.swift
 swift package compute-checksum OpenCV.xcframework.zip | xargs -I '{}' sed -I '' 's/\(checksum: "\).*\("\)/\1{}\2/' ../Package.swift

--- a/privacy/PrivacyInfo.xcprivacy
+++ b/privacy/PrivacyInfo.xcprivacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict/>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict/>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Hi r0ml - 

Saw this package roll past, and your name as "owner" caught my eye. I appreciated insights you shared a dozen or so years ago at some tech conference - likely one of the O'Reilly open source ones - and thought I'd offer this up as a very belated thank you.

Apple's getting picky about having privacy manifests, and code signing, for any binary frameworks that are flowing into the App Store (and possibly Notarization). I [worked out](https://rhonabwy.com/2024/02/18/embedding-a-privacy-manifest-into-an-xcframework/) the PITA setup on how to embed such a thing with some help from DTS, and thought this package would benefit from the same.

The manifest I'm adding (and embedding in postbuild.sh) is just barebones, but I believe it's reasonably correct. I don't believe there's any captured data when using OpenCV, and I don't think it uses any of the [system APIs that Apple's getting cranky about](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api). Still, worth noting that I didn't do any deep dive to verify correctness of those assertions.

Cheers,

  -- joe